### PR TITLE
Fix decorators swallowing func return value

### DIFF
--- a/src/aws_secretsmanager_caching/decorators.py
+++ b/src/aws_secretsmanager_caching/decorators.py
@@ -46,7 +46,7 @@ class InjectSecretString:
             """
             Internal function to execute wrapped function
             """
-            func(secret, *args, **kwargs)
+            return func(secret, *args, **kwargs)
 
         return _wrapped_func
 
@@ -99,6 +99,6 @@ class InjectKeywordedSecretString:
             """
             Internal function to execute wrapped function
             """
-            func(*args, **resolved_kwargs, **kwargs)
+            return func(*args, **resolved_kwargs, **kwargs)
 
         return _wrapped_func


### PR DESCRIPTION
*Description of changes:*
The return value of wrapped functions is swallowed by the decorator. This fix conveys the wrapped function's intended return value.

Without this change, any decorated function is unable to return a value to its caller.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
